### PR TITLE
Add GitHub ci action to build Docker images

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,57 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [ created ]
+
+permissions: write-all
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          # password: ${{ secrets.GITHUB_TOKEN }}  # Doesn't work for some reason
+          password: ${{ secrets.PAT_FOR_GHCR }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Sources:  github:Tyrrrz/DiscordChatExporter
 #
 # Usage:    You'll need to mount a volume containing config.json to /app/config
-#           The export directory goes to /app/export
+#           The export directory goes to /app/exports
 ################################################################################
 FROM alpine:latest
 


### PR DESCRIPTION
Hi, thanks a lot for dockerizing this!

I've added a GitHub ci action to build and push amd64, arm64 images to ghcr.io on every new commit.

In case anyone reading this wants to set up this action for their own repo, you'll need to create a personal access token (classic) from: https://github.com/settings/tokens

and then name it as `PAT_FOR_GHCR` in repo's secrets (or rename it in `build-docker.yml`).

Triggering the github actions ci should publish the image to ghcr.io, it can then be set to public visibility in package settings from: https://ghcr.io/github-username/discordchatexporter-incrementalbackup:main

Usage:
```sh
$ docker run --rm -it -v "$(pwd)/config:/app/config" -v "$(pwd)/export:/app/exports" ghcr.io/github-username/discordchatexporter-incrementalbackup:main
```

-------------------

This is how it looks for me:
https://github.com/ritiek/DiscordChatExporter-incrementalBackup/actions
https://ghcr.io/ritiek/discordchatexporter-incrementalbackup:main

Seems to work fine for me with:
```sh
$ docker run --rm -it -v "$(pwd)/config:/app/config" -v "$(pwd)/export:/app/exports" ghcr.io/ritiek/discordchatexporter-incrementalbackup:main
```
```